### PR TITLE
Security: disallow classes/objects in proxy cache

### DIFF
--- a/plugins/proxy/lib/cache.php
+++ b/plugins/proxy/lib/cache.php
@@ -18,7 +18,7 @@ final class rex_proxy_cache
 
         $cached = rex_file::get($file);
         if ($cached) {
-            [$content, $contentType, $storeTime] = unserialize($cached);
+            [$content, $contentType, $storeTime] = unserialize($cached, false /* disallow classes */);
 
             if (self::isExpired($storeTime)) {
                 // existing cache expired


### PR DESCRIPTION
Mitigates serializing attack vectors

not tested!